### PR TITLE
Docker Setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Use an official Node.js runtime as the base image
+FROM node:20-alpine
+
+# Install bash
+RUN apk update && apk add --no-cache bash
+
+# Set the working directory in the container to /app
+WORKDIR /app
+
+# Copy package.json and package-lock.json to the working directory
+COPY package*.json ./
+
+# Install the application's dependencies inside the Docker image
+RUN npm install
+
+# Copy the rest of the application's code to the working directory
+COPY . .
+
+# Copy wait-for-mysql.sh script and make it executable
+COPY wait-for-mysql.sh /usr/local/bin/wait-for-mysql.sh
+RUN chmod +x /usr/local/bin/wait-for-mysql.sh
+
+# Expose port 3000 to the outside world
+EXPOSE 3000
+
+# Start the application
+CMD [ "npm", "start" ]

--- a/Dockerfile.mysql
+++ b/Dockerfile.mysql
@@ -1,0 +1,6 @@
+FROM mysql:8.0
+
+COPY ./init-db.sh /docker-entrypoint-initdb.d/init-db.sh
+COPY ./misc/binkjs.sql /docker-entrypoint-initdb.d/binkjs.sql
+
+RUN chmod +x /docker-entrypoint-initdb.d/init-db.sh

--- a/README.md
+++ b/README.md
@@ -136,17 +136,17 @@ You will need to register for an AWS account, if you don't already have one.
 
 [Get AWS Credentials](https://aws.amazon.com/blogs/security/how-to-find-update-access-keys-password-mfa-aws-management-console/)
 
-For local development, you should also set up an S3 bucket with public read permissions. 
+For local development, you should also set up an S3 bucket with public read permissions.
 
-[Create an S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html). 
+[Create an S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html).
 
 It's also recommended that you create a folder within your bucket called `public`.
 
-[Set appropriate permissions for your S3 bucket.](https://docs.aws.amazon.com/AmazonS3/latest/userguide/managing-acls.html) Your bucket will need to be publicly accessible. 
+[Set appropriate permissions for your S3 bucket.](https://docs.aws.amazon.com/AmazonS3/latest/userguide/managing-acls.html) Your bucket will need to be publicly accessible.
 
-Your S3 bucket will also not have ACLs allowed by default. If ACLs are not allowed, you will not be able to upload assets (tracks, images, videos) via the Binkjs admin console. 
+Your S3 bucket will also not have ACLs allowed by default. If ACLs are not allowed, you will not be able to upload assets (tracks, images, videos) via the Binkjs admin console.
 
-In order to resolve this, do the following: 
+In order to resolve this, do the following:
 
 - Go to the S3 Console and select your bucket
 - Go to Permissions
@@ -224,3 +224,17 @@ Check out the [example nginx.conf](./misc/binkjs-nginx.conf) configuration file 
 ### Ubuntu/Systemd Service
 
 You'll want to configure a [Systemd Service](https://docs.fedoraproject.org/en-US/quick-docs/systemd-understanding-and-administering/) for BINK.js that is **separate** from the frontend reverse proxy, like Nginx (see previous section).  This Service will start BINK.js when your machine turns on, and can restart BINK.js if it crashes. Checkout our [example systemd service](./misc/binkjs.service) for more information.
+
+## Docker-Compose Setup
+
+You can also quickly set up your development environment with Docker Compose.
+
+You will still need to set up a public S3 bucket as described above.
+
+You will also need to configure your settings.json locally as described above.
+
+Once these are set up, run:
+
+`docker-compose up --build`
+
+And you should be able to access BINK at `http://localhost:3001` and begin development.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,53 @@
+version: "3.8"
+services:
+  mysql:
+    build:
+      context: .
+      dockerfile: Dockerfile.mysql
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_RANDOM_ROOT_PASSWORD: "yes"
+      MYSQL_ROOT_PASSWORD: rootpassword
+      MYSQL_AUTHENTICATION_PLUGIN: mysql_native_password
+      MYSQL_USER: binkjsuser
+      MYSQL_PASSWORD: password
+      MYSQL_DATABASE: binkjs
+    networks:
+      - binkjs
+    volumes:
+      - ./misc/binkjs.sql:/docker-entrypoint-initdb.d/binkjs.sql
+      - ./init-db.sh:/docker-entrypoint-initdb.d/init-db.sh
+      - mysql-data:/var/lib/mysql
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    # entrypoint: ["/docker-entrypoint-initdb.d/init-db.sh"]
+
+  binkjs:
+    build: .
+    ports:
+      - 3000:3000
+    volumes:
+      - ./src:/app/src # Enables live reload
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      MYSQL_HOST: mysql
+      MYSQL_USER: binkjsuser
+      MYSQL_PASSWORD: password
+      MYSQL_DATABASE: binkjs
+    networks:
+      - binkjs
+    entrypoint: ["./wait-for-mysql.sh", "mysql:3306", "--", "npm", "start"]
+
+volumes:
+  mysql-data:
+
+networks:
+  binkjs:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-    # entrypoint: ["/docker-entrypoint-initdb.d/init-db.sh"]
 
   binkjs:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
   binkjs:
     build: .
     ports:
-      - 3000:3000
+      - 3001:3001
     volumes:
       - ./src:/app/src # Enables live reload
     depends_on:

--- a/init-db.sh
+++ b/init-db.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+# Start MySQL server in the background
+/docker-entrypoint.sh mysqld &
+
+# Wait for MySQL to be ready
+until mysqladmin ping -h "localhost" --silent; do
+    echo 'waiting for mysqld to be connectable...'
+    sleep 2
+done
+
+# Create the database if it doesn't exist
+mysql -u root -prootpassword -e "CREATE DATABASE IF NOT EXISTS binkjs;"
+
+# Execute the SQL script
+mysql -u root -prootpassword binkjs </docker-entrypoint-initdb.d/binkjs.sql
+
+# Grant privileges to the user
+mysql -u root -prootpassword -e "GRANT ALL PRIVILEGES ON binkjs.* TO 'binkjsuser'@'%'; FLUSH PRIVILEGES;"
+
+# Keep the container running
+tail -f /dev/null

--- a/wait-for-mysql.sh
+++ b/wait-for-mysql.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# wait-for-it.sh
+
+set -e
+
+host="$1"
+shift
+cmd="$@"
+
+until nc -z "$host" 3306; do
+    echo >&2 "MySQL is unavailable - sleeping"
+    sleep 1
+done
+
+echo >&2 "MySQL is up - executing command"
+exec $cmd


### PR DESCRIPTION
This PR adds Docker Compose functionality to (somewhat) automate the dev environment steps and local infrastructure. 

The app is built into a container. 

The db is built into a separate container. 

They talk. 

A couple other various scripts and helpers were added to facilitate this, like a Dockerfile for each, a healthcheck bash script, and a db init shell script. These bash things could probably be packed into the docker-compose or Dockerfiles later, but putting them here for now. 