### PR TITLE
hotfix: change to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,11 +36,12 @@ services:
       timeout: 5s
       retries: 5
     volumes:
-      - ./src:/app/src
+      - ./:/app
     depends_on:
       mysql:
         condition: service_healthy
     environment:
+      NODE_ENV: development
       MYSQL_HOST: mysql
       MYSQL_USER: binkjsuser
       MYSQL_PASSWORD: password


### PR DESCRIPTION
Made a quick change to get node_env set to development to ensure nodemon works as intended from a docker-compose setup. 